### PR TITLE
BBBdistributions.py: Update logpdf

### DIFF
--- a/utils/BBBdistributions.py
+++ b/utils/BBBdistributions.py
@@ -78,7 +78,7 @@ class Normalout(Distribution):
 
     def logpdf(self, x):
         c = - float(0.5 * math.log(2 * math.pi))
-        return c - 0.5 * self.std - (x - self.mu).pow(2) / (2 * torch.exp(self.std))
+        return c - 0.5 * math.log(self.std) - (x - self.mu).pow(2) / (2 * self.std)
 
     def pdf(self, x):
         return torch.exp(self.logpdf(x))


### PR DESCRIPTION
Shouldn't this be the case in the Normalout distribution, given that the entry parameter is the standard deviation and not the log variance?